### PR TITLE
feat: 自我进化系统 - 动态节点发现与创建 / Self-Evolution System - Dynamic Node Discovery & Creation

### DIFF
--- a/Python/ue_editor_mcp/registry/actions.py
+++ b/Python/ue_editor_mcp/registry/actions.py
@@ -32,6 +32,9 @@ def register_all_actions(registry: ActionRegistry) -> None:
     registry.register_many(_MATERIAL_ACTIONS)
     registry.register_many(_WIDGET_ACTIONS)
     registry.register_many(_INPUT_ACTIONS)
+    registry.register_many(_ASYNC_ACTION_ACTIONS)
+    registry.register_many(_WIDGET_VARIABLE_ACTIONS)
+    registry.register_many(_SELF_EVOLUTION_ACTIONS)
 
 
 # =========================================================================
@@ -3123,5 +3126,197 @@ _INPUT_ACTIONS = [
             },
             "required": ["context_name", "action_name", "key"]
         },
+    ),
+]
+
+
+# =========================================================================
+# Widget Is Variable
+# =========================================================================
+_WIDGET_VARIABLE_ACTIONS = [
+    ActionDef(
+        id="widget.set_is_variable",
+        command="set_widget_is_variable",
+        tags=("widget", "umg", "variable", "is_variable", "promote"),
+        description="Set bIsVariable on a widget component, enabling it to be referenced in Blueprint graphs.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "widget_name": {"type": "string", "description": "Name of the Widget Blueprint"},
+                "target": {"type": "string", "description": "Widget component name to set as variable"},
+                "is_variable": {"type": "boolean", "description": "true to mark as variable (default true)"}
+            },
+            "required": ["widget_name", "target"]
+        },
+        examples=(
+            {"widget_name": "WBP_Weather", "target": "TempText"},
+            {"widget_name": "WBP_HUD", "target": "HealthBar", "is_variable": False},
+        ),
+    ),
+]
+
+
+# =========================================================================
+# Async Action Nodes (Third-party plugin support: UForge HTTP, etc.)
+# =========================================================================
+_ASYNC_ACTION_ACTIONS = [
+    ActionDef(
+        id="node.add_async_action",
+        command="add_async_action_node",
+        tags=("node", "async", "action", "latent", "third-party", "uforge", "http"),
+        description="Add an async action node (UK2Node_AsyncAction) by class name. Supports any UBlueprintAsyncActionBase subclass including third-party plugins like UForge HTTP & JSON Utility.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "blueprint_name": {"type": "string", "description": "Name of the target Blueprint"},
+                "class_name": {"type": "string", "description": "C++ class name of the async action (e.g. 'HTTPProxyAsync', 'DownloadImage'). Supports fuzzy matching."},
+                "factory_function": {"type": "string", "description": "Factory function name (auto-detected if omitted)"},
+                "node_position": {"type": "array", "items": {"type": "number"}, "description": "[X, Y] position"},
+                "graph_name": {"type": "string", "description": "Target graph (default: EventGraph)"},
+                "pin_defaults": {"type": "object", "description": "Object mapping pin_name -> default_value string"}
+            },
+            "required": ["blueprint_name", "class_name"]
+        },
+        examples=(
+            {"blueprint_name": "WBP_Weather", "class_name": "HTTPProxyAsync", "node_position": [500, 0]},
+            {"blueprint_name": "BP_Player", "class_name": "DownloadImage", "node_position": [300, 0]},
+        ),
+    ),
+]
+
+
+# =========================================================================
+# Self-Evolution: Dynamic Node Discovery & Creation
+# =========================================================================
+_SELF_EVOLUTION_ACTIONS = [
+    ActionDef(
+        id="node.search_catalog",
+        command="search_catalog",
+        tags=("node", "search", "catalog", "discover", "browse", "action", "database", "self-evolution"),
+        description=(
+            "Search the Blueprint action catalog for available nodes. "
+            "Queries UE's FBlueprintActionDatabase to discover ALL registered Blueprint actions "
+            "(engine functions, third-party plugins, project functions, etc.). "
+            "Returns spawner_id that can be used with node.add_generic to create any node."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "keyword": {
+                    "type": "string",
+                    "description": "Search term (min 2 chars). Matches against action name, category, and keywords.",
+                },
+                "category": {
+                    "type": "string",
+                    "description": "Optional category filter to narrow results (e.g. 'Math', 'String', 'HTTP').",
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "Max results to return (default: 50, max: 200).",
+                },
+            },
+            "required": ["keyword"],
+        },
+        examples=(
+            {"keyword": "Print String"},
+            {"keyword": "HTTP", "max_results": 20},
+            {"keyword": "Get", "category": "Math", "max_results": 10},
+            {"keyword": "TryGet", "max_results": 30},
+        ),
+    ),
+    ActionDef(
+        id="node.add_generic",
+        command="add_generic_node",
+        tags=("node", "add", "generic", "create", "spawn", "universal", "self-evolution"),
+        description=(
+            "Create ANY Blueprint node using a spawner_id from node.search_catalog or node.suggest_next. "
+            "This is the universal node creator — can spawn function calls, events, macros, "
+            "async actions, struct operations, and any third-party plugin node."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "blueprint_name": {
+                    "type": "string",
+                    "description": "Name of the target Blueprint",
+                },
+                "spawner_id": {
+                    "type": "string",
+                    "description": "Spawner ID obtained from node.search_catalog or node.suggest_next",
+                },
+                "node_position": {
+                    "type": "array",
+                    "items": {"type": "number"},
+                    "description": "[X, Y] position in the graph",
+                },
+                "graph_name": {
+                    "type": "string",
+                    "description": "Target graph (default: EventGraph)",
+                },
+                "pin_defaults": {
+                    "type": "object",
+                    "description": "Object mapping pin_name -> default_value string",
+                },
+            },
+            "required": ["blueprint_name", "spawner_id"],
+        },
+        examples=(
+            {"blueprint_name": "BP_Player", "spawner_id": "sp_42", "node_position": [300, 0]},
+            {
+                "blueprint_name": "WBP_Weather",
+                "spawner_id": "sp_7",
+                "node_position": [500, 100],
+                "pin_defaults": {"URL": "https://api.example.com"},
+            },
+        ),
+    ),
+    ActionDef(
+        id="node.suggest_next",
+        command="suggest_next",
+        tags=("node", "suggest", "context", "pin", "compatible", "next", "self-evolution"),
+        description=(
+            "Given a node pin, suggest compatible nodes that can connect to it. "
+            "Uses UE's native context-sensitive menu system (same as right-click drag from pin). "
+            "Returns spawner_id for each suggestion, usable with node.add_generic."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "blueprint_name": {
+                    "type": "string",
+                    "description": "Name of the target Blueprint",
+                },
+                "node_id": {
+                    "type": "string",
+                    "description": "GUID of the source node",
+                },
+                "pin_name": {
+                    "type": "string",
+                    "description": "Name of the pin to find compatible connections for",
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "Max results (default: 30, max: 100)",
+                },
+                "graph_name": {
+                    "type": "string",
+                    "description": "Target graph (default: EventGraph)",
+                },
+            },
+            "required": ["blueprint_name", "node_id", "pin_name"],
+        },
+        examples=(
+            {
+                "blueprint_name": "BP_Player",
+                "node_id": "A1B2C3D4-...",
+                "pin_name": "ReturnValue",
+            },
+            {
+                "blueprint_name": "WBP_Weather",
+                "node_id": "E5F6A7B8-...",
+                "pin_name": "OnSuccess",
+                "max_results": 20,
+            },
+        ),
     ),
 ]

--- a/Python/ue_editor_mcp/registry/actions.py
+++ b/Python/ue_editor_mcp/registry/actions.py
@@ -2034,11 +2034,14 @@ _GRAPH_ACTIONS = [
                         "properties": {
                             "op": {"type": "string", "enum": ["add_node", "remove_node", "set_node_property", "connect", "disconnect", "add_variable", "set_variable_default", "set_pin_default"]},
                             "id": {"type": "string", "description": "(add_node) Temp ID for referencing within this patch"},
-                            "node_type": {"type": "string", "description": "(add_node) Event, CustomEvent, FunctionCall, Branch, VariableGet, VariableSet, Cast, Self, Reroute, MacroInstance"},
+                            "node_type": {"type": "string", "description": "(add_node) Event, CustomEvent, FunctionCall, Branch, VariableGet, VariableSet, Cast, Self, Reroute, MacroInstance, CreateDelegate, Delay, CreateWidget, InputAction, FormatText, SpawnActorFromClass"},
                             "event_name": {"type": "string", "description": "(add_node/Event) Event name e.g. BeginPlay"},
                             "function_name": {"type": "string", "description": "(add_node/FunctionCall) Function name"},
                             "target_class": {"type": "string", "description": "(add_node/FunctionCall) Owning class (self, GameplayStatics, Math, etc.)"},
                             "variable_name": {"type": "string", "description": "(add_node/VariableGet|Set) Variable name"},
+                            "action_name": {"type": "string", "description": "(add_node/InputAction) Input action name"},
+                            "class_name": {"type": "string", "description": "(add_node/CreateWidget|SpawnActorFromClass) Class path e.g. /Game/UI/WBP_HUD.WBP_HUD_C"},
+                            "duration": {"type": "number", "description": "(add_node/Delay) Delay duration in seconds"},
                             "defaults": {"type": "object", "description": "(add_node/FunctionCall) Pin default values {pin_name: value}"},
                             "node": {"type": "string", "description": "(various ops) Node reference: temp ID, GUID, or $last_node"},
                             "from": {"type": "object", "description": "(connect) {node, pin}"},
@@ -2727,7 +2730,8 @@ _WIDGET_ACTIONS = [
                 "position": {"type": "array", "items": {"type": "number"}, "description": "[X, Y]"},
                 "size": {"type": "array", "items": {"type": "number"}, "description": "[Width, Height]"},
                 "font_size": {"type": "integer", "description": "Font size"},
-                "color": {"type": "array", "items": {"type": "number"}, "description": "[R, G, B, A]"}
+                "color": {"type": "array", "items": {"type": "number"}, "description": "[R, G, B, A]"},
+                "parent": {"type": "string", "description": "Optional parent container name. If provided, widget is added as child of this container instead of root canvas."}
             },
             "required": ["widget_name", "component_type", "component_name"]
         },
@@ -2821,7 +2825,12 @@ _WIDGET_ACTIONS = [
                 "is_enabled": {"type": "boolean", "description": "Whether widget is enabled"},
                 "h_align": {"type": "string", "description": "Horizontal alignment: Fill, Left, Center, Right"},
                 "v_align": {"type": "string", "description": "Vertical alignment: Fill, Top, Center, Bottom"},
-                "padding": {"type": "array", "items": {"type": "number"}, "description": "[Left, Top, Right, Bottom]"}
+                "padding": {"type": "array", "items": {"type": "number"}, "description": "[Left, Top, Right, Bottom]"},
+                "anchors": {"type": "array", "items": {"type": "number"}, "description": "[MinX, MinY, MaxX, MaxY] CanvasPanel anchors (0-1). Presets: [0,0,0,0]=TopLeft, [0.5,0.5,0.5,0.5]=Center, [0,0,1,1]=Stretch"},
+                "alignment": {"type": "array", "items": {"type": "number"}, "description": "[X, Y] alignment pivot (0-1). E.g. [0.5, 0.5] for center"},
+                "auto_size": {"type": "boolean", "description": "Enable auto-size for CanvasPanel slot (overrides explicit size)"},
+                "z_order": {"type": "integer", "description": "Z-order in CanvasPanel (higher = on top)"},
+                "size_rule": {"type": "string", "enum": ["Auto", "Fill"], "description": "Size rule for VerticalBox/HorizontalBox slots"}
             },
             "required": ["widget_name", "target"]
         },

--- a/Python/ue_editor_mcp/server_unified.py
+++ b/Python/ue_editor_mcp/server_unified.py
@@ -251,7 +251,7 @@ TOOLS = [
         description=(
             "Execute multiple actions in a SINGLE TCP round-trip via C++ batch_execute. "
             "Much faster than calling ue_actions_run multiple times. "
-            "Stops at first failure unless continue_on_error is true. "
+            "Continues past failures by default; set continue_on_error=false to stop at first failure. "
             f"Max {_MAX_BATCH} actions per batch."
         ),
         inputSchema={
@@ -275,7 +275,7 @@ TOOLS = [
                 },
                 "continue_on_error": {
                     "type": "boolean",
-                    "description": "If true, continue executing after a failure (default: false)",
+                    "description": "If false, stop at first failure (default: true)",
                 },
             },
             "required": ["actions"],
@@ -468,7 +468,7 @@ def _handle_tool(name: str, args: dict) -> Any:
     # instead of N individual TCP calls.
     if name == "ue_batch":
         actions = args.get("actions", [])
-        continue_on_error = args.get("continue_on_error", False)
+        continue_on_error = args.get("continue_on_error", True)
 
         if len(actions) > _MAX_BATCH:
             return {"success": False, "error": f"Max {_MAX_BATCH} actions per batch, got {len(actions)}"}

--- a/Source/UEEditorMCP/Private/Actions/GraphActions.cpp
+++ b/Source/UEEditorMCP/Private/Actions/GraphActions.cpp
@@ -28,6 +28,9 @@
 #include "K2Node_Knot.h"
 #include "K2Node_CreateDelegate.h"
 #include "K2Node_ExecutionSequence.h"
+#include "K2Node_InputAction.h"
+#include "K2Node_FormatText.h"
+#include "Kismet/KismetSystemLibrary.h"
 #include "Kismet2/BlueprintEditorUtils.h"
 #include "Kismet2/KismetEditorUtilities.h"
 #include "EdGraphUtilities.h"
@@ -1325,10 +1328,173 @@ FPatchOpResult FApplyPatchAction::ExecuteAddNode(const FPatchOp& Op, UBlueprint*
 
 		CreatedNode = DelegateNode;
 	}
+	// ---- OPT-2: New special node types ----
+	else if (NodeType.Equals(TEXT("Delay"), ESearchCase::IgnoreCase))
+	{
+		// Create Delay as a proper latent function call via KismetSystemLibrary::Delay
+		UFunction* DelayFunc = UKismetSystemLibrary::StaticClass()->FindFunctionByName(TEXT("Delay"));
+		if (!DelayFunc)
+		{
+			Result.bSuccess = false;
+			Result.Message = TEXT("Delay function not found in KismetSystemLibrary");
+			return Result;
+		}
+
+		UK2Node_CallFunction* FuncNode = NewObject<UK2Node_CallFunction>(Graph);
+		FuncNode->SetFromFunction(DelayFunc);
+		FuncNode->NodePosX = Position.X;
+		FuncNode->NodePosY = Position.Y;
+		Graph->AddNode(FuncNode, false, false);
+		FuncNode->AllocateDefaultPins();
+
+		// Set Duration default if provided
+		double Duration = 0.0;
+		if (Op.Params->TryGetNumberField(TEXT("duration"), Duration))
+		{
+			UEdGraphPin* DurationPin = FMCPCommonUtils::FindPin(FuncNode, TEXT("Duration"), EGPD_Input);
+			if (DurationPin)
+			{
+				DurationPin->DefaultValue = FString::SanitizeFloat(Duration);
+			}
+		}
+
+		CreatedNode = FuncNode;
+	}
+	else if (NodeType.Equals(TEXT("CreateWidget"), ESearchCase::IgnoreCase))
+	{
+		// K2Node_CreateWidget is in a Private header, so we find and spawn it by class name
+		UClass* CreateWidgetClass = FindFirstObject<UClass>(TEXT("K2Node_CreateWidget"), EFindFirstObjectOptions::None);
+		if (!CreateWidgetClass)
+		{
+			// Fallback: scan loaded classes
+			for (TObjectIterator<UClass> It; It; ++It)
+			{
+				if (It->GetName() == TEXT("K2Node_CreateWidget"))
+				{
+					CreateWidgetClass = *It;
+					break;
+				}
+			}
+		}
+		if (!CreateWidgetClass)
+		{
+			Result.bSuccess = false;
+			Result.Message = TEXT("K2Node_CreateWidget class not found. Is the UMGEditor module loaded?");
+			return Result;
+		}
+
+		UK2Node* WidgetNode = Cast<UK2Node>(NewObject<UEdGraphNode>(Graph, CreateWidgetClass));
+		if (!WidgetNode)
+		{
+			Result.bSuccess = false;
+			Result.Message = TEXT("Failed to create CreateWidget node");
+			return Result;
+		}
+		WidgetNode->NodePosX = Position.X;
+		WidgetNode->NodePosY = Position.Y;
+		Graph->AddNode(WidgetNode, false, false);
+		WidgetNode->AllocateDefaultPins();
+
+		// Optionally set the widget class via the "Class" pin
+		FString ClassName;
+		if (Op.Params->TryGetStringField(TEXT("class_name"), ClassName) && !ClassName.IsEmpty())
+		{
+			UClass* WidgetClass = StaticLoadClass(UObject::StaticClass(), nullptr, *ClassName);
+			if (WidgetClass)
+			{
+				UEdGraphPin* ClassPin = FMCPCommonUtils::FindPin(WidgetNode, TEXT("Class"), EGPD_Input);
+				if (ClassPin)
+				{
+					const UEdGraphSchema_K2* K2Schema = GetDefault<UEdGraphSchema_K2>();
+					K2Schema->TrySetDefaultObject(*ClassPin, WidgetClass);
+					WidgetNode->ReconstructNode();
+				}
+			}
+		}
+
+		CreatedNode = WidgetNode;
+	}
+	else if (NodeType.Equals(TEXT("InputAction"), ESearchCase::IgnoreCase))
+	{
+		FString ActionName;
+		if (!Op.Params->TryGetStringField(TEXT("action_name"), ActionName) || ActionName.IsEmpty())
+		{
+			Result.bSuccess = false;
+			Result.Message = TEXT("add_node(InputAction): 'action_name' is required");
+			return Result;
+		}
+
+		UK2Node_InputAction* InputNode = FEdGraphSchemaAction_K2NewNode::SpawnNode<UK2Node_InputAction>(
+			Graph, Position, EK2NewNodeFlags::None,
+			[&ActionName](UK2Node_InputAction* Node)
+			{
+				Node->InputActionName = FName(*ActionName);
+			}
+		);
+		if (!InputNode)
+		{
+			Result.bSuccess = false;
+			Result.Message = TEXT("Failed to create InputAction node");
+			return Result;
+		}
+
+		CreatedNode = InputNode;
+	}
+	else if (NodeType.Equals(TEXT("FormatText"), ESearchCase::IgnoreCase))
+	{
+		UK2Node_FormatText* FormatNode = FEdGraphSchemaAction_K2NewNode::SpawnNode<UK2Node_FormatText>(
+			Graph, Position, EK2NewNodeFlags::None,
+			[](UK2Node_FormatText* Node) {}
+		);
+		if (!FormatNode)
+		{
+			Result.bSuccess = false;
+			Result.Message = TEXT("Failed to create FormatText node");
+			return Result;
+		}
+
+		CreatedNode = FormatNode;
+	}
+	else if (NodeType.Equals(TEXT("SpawnActorFromClass"), ESearchCase::IgnoreCase))
+	{
+		UK2Node_SpawnActorFromClass* SpawnNode = FEdGraphSchemaAction_K2NewNode::SpawnNode<UK2Node_SpawnActorFromClass>(
+			Graph, Position, EK2NewNodeFlags::None,
+			[](UK2Node_SpawnActorFromClass* Node) {}
+		);
+		if (!SpawnNode)
+		{
+			Result.bSuccess = false;
+			Result.Message = TEXT("Failed to create SpawnActorFromClass node");
+			return Result;
+		}
+
+		// Optionally set spawn class
+		FString ClassName;
+		if (Op.Params->TryGetStringField(TEXT("class_name"), ClassName) && !ClassName.IsEmpty())
+		{
+			UClass* SpawnClass = FindFirstObject<UClass>(*ClassName, EFindFirstObjectOptions::None);
+			if (!SpawnClass)
+			{
+				SpawnClass = StaticLoadClass(UObject::StaticClass(), nullptr, *ClassName);
+			}
+			if (SpawnClass)
+			{
+				UEdGraphPin* ClassPin = SpawnNode->GetClassPin();
+				if (ClassPin)
+				{
+					const UEdGraphSchema_K2* K2Schema = GetDefault<UEdGraphSchema_K2>();
+					K2Schema->TrySetDefaultObject(*ClassPin, SpawnClass);
+					SpawnNode->ReconstructNode();
+				}
+			}
+		}
+
+		CreatedNode = SpawnNode;
+	}
 	else
 	{
 		Result.bSuccess = false;
-		Result.Message = FString::Printf(TEXT("add_node: unsupported node_type '%s'. Supported: Event, CustomEvent, FunctionCall, Branch, Sequence, VariableGet, VariableSet, Cast, Self, Reroute, MacroInstance, CreateDelegate"), *NodeType);
+		Result.Message = FString::Printf(TEXT("add_node: unsupported node_type '%s'. Supported: Event, CustomEvent, FunctionCall, Branch, Sequence, VariableGet, VariableSet, Cast, Self, Reroute, MacroInstance, CreateDelegate, Delay, CreateWidget, InputAction, FormatText, SpawnActorFromClass"), *NodeType);
 		return Result;
 	}
 

--- a/Source/UEEditorMCP/Private/Actions/NodeActions.cpp
+++ b/Source/UEEditorMCP/Private/Actions/NodeActions.cpp
@@ -57,6 +57,12 @@
 #include "GraphEditorActions.h"
 #include "MCPBridge.h"
 #include "GraphEditor.h"
+// Self-Evolution includes
+#include "BlueprintActionDatabase.h"
+#include "BlueprintNodeSpawner.h"
+#include "BlueprintActionMenuBuilder.h"
+#include "BlueprintActionMenuUtils.h"
+#include "BlueprintActionMenuItem.h"
 
 // ============================================================================
 // Graph Operations (connect, find, delete, inspect)
@@ -5239,5 +5245,555 @@ TSharedPtr<FJsonObject> FGetSelectedNodesAction::ExecuteInternal(const TSharedPt
 	ResultData->SetNumberField(TEXT("edge_count"), EdgesArray.Num());
 	ResultData->SetArrayField(TEXT("nodes"), NodesArray);
 	ResultData->SetArrayField(TEXT("edges"), EdgesArray);
+	return CreateSuccessResponse(ResultData);
+}
+
+
+// ============================================================================
+// Async Action Nodes (Third-party plugin support: UForge, etc.)
+// ============================================================================
+
+#include "Kismet/BlueprintAsyncActionBase.h"
+#include "K2Node_AsyncAction.h"
+
+UClass* FAddAsyncActionNodeAction::FindAsyncActionClass(const FString& ClassName) const
+{
+	// Try exact match first via iteration (ANY_PACKAGE removed in UE 5.7)
+	for (TObjectIterator<UClass> It; It; ++It)
+	{
+		UClass* TestClass = *It;
+		if (TestClass && TestClass->GetName() == ClassName
+			&& TestClass->IsChildOf(UBlueprintAsyncActionBase::StaticClass()))
+		{
+			return TestClass;
+		}
+	}
+
+	// Fuzzy search: partial name match
+	for (TObjectIterator<UClass> It; It; ++It)
+	{
+		UClass* TestClass = *It;
+		if (TestClass && TestClass->IsChildOf(UBlueprintAsyncActionBase::StaticClass()))
+		{
+			if (TestClass->GetName().Contains(ClassName))
+			{
+				return TestClass;
+			}
+		}
+	}
+
+	return nullptr;
+}
+
+UFunction* FAddAsyncActionNodeAction::FindFactoryFunction(UClass* AsyncClass, const FString& FunctionName) const
+{
+	if (!FunctionName.IsEmpty())
+	{
+		return AsyncClass->FindFunctionByName(FName(*FunctionName));
+	}
+
+	// Auto-detect: find the first static function that returns an object of this class
+	for (TFieldIterator<UFunction> It(AsyncClass, EFieldIteratorFlags::IncludeSuper); It; ++It)
+	{
+		UFunction* Func = *It;
+		if (Func && Func->HasAnyFunctionFlags(FUNC_Static | FUNC_BlueprintCallable))
+		{
+			FObjectPropertyBase* ReturnProp = nullptr;
+			for (TFieldIterator<FProperty> PropIt(Func); PropIt; ++PropIt)
+			{
+				if (PropIt->HasAnyPropertyFlags(CPF_ReturnParm))
+				{
+					ReturnProp = CastField<FObjectPropertyBase>(*PropIt);
+					break;
+				}
+			}
+			if (ReturnProp && ReturnProp->PropertyClass && AsyncClass->IsChildOf(ReturnProp->PropertyClass))
+			{
+				return Func;
+			}
+		}
+	}
+
+	return nullptr;
+}
+
+bool FAddAsyncActionNodeAction::Validate(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context, FString& OutError)
+{
+	FString ClassName;
+	if (!GetRequiredString(Params, TEXT("class_name"), ClassName, OutError)) return false;
+	return ValidateGraph(Params, Context, OutError);
+}
+
+TSharedPtr<FJsonObject> FAddAsyncActionNodeAction::ExecuteInternal(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context)
+{
+	FString ClassName = Params->GetStringField(TEXT("class_name"));
+	FString FactoryFunctionName = GetOptionalString(Params, TEXT("factory_function"));
+	FVector2D Position = GetNodePosition(Params);
+
+	UBlueprint* Blueprint = GetTargetBlueprint(Params, Context);
+	UEdGraph* TargetGraph = GetTargetGraph(Params, Context);
+
+	// Find the async action class
+	UClass* AsyncClass = FindAsyncActionClass(ClassName);
+	if (!AsyncClass)
+	{
+		// List available async action classes for helpful error
+		TArray<FString> AvailableClasses;
+		for (TObjectIterator<UClass> It; It; ++It)
+		{
+			UClass* TestClass = *It;
+			if (TestClass && TestClass->IsChildOf(UBlueprintAsyncActionBase::StaticClass())
+				&& !TestClass->HasAnyClassFlags(CLASS_Abstract))
+			{
+				AvailableClasses.Add(TestClass->GetName());
+			}
+		}
+		AvailableClasses.Sort();
+
+		FString AvailableStr;
+		int32 Count = FMath::Min(AvailableClasses.Num(), 20);
+		for (int32 i = 0; i < Count; ++i)
+		{
+			if (i > 0) AvailableStr += TEXT(", ");
+			AvailableStr += AvailableClasses[i];
+		}
+		if (AvailableClasses.Num() > 20)
+		{
+			AvailableStr += FString::Printf(TEXT(" ... and %d more"), AvailableClasses.Num() - 20);
+		}
+
+		return CreateErrorResponse(FString::Printf(
+			TEXT("Async action class '%s' not found. Available: [%s]"),
+			*ClassName, *AvailableStr));
+	}
+
+	// Find the factory function
+	UFunction* FactoryFunction = FindFactoryFunction(AsyncClass, FactoryFunctionName);
+	if (!FactoryFunction)
+	{
+		TArray<FString> AvailableFunctions;
+		for (TFieldIterator<UFunction> It(AsyncClass, EFieldIteratorFlags::IncludeSuper); It; ++It)
+		{
+			UFunction* Func = *It;
+			if (Func && Func->HasAnyFunctionFlags(FUNC_Static | FUNC_BlueprintCallable))
+			{
+				AvailableFunctions.Add(Func->GetName());
+			}
+		}
+		FString AvailableStr = FString::Join(AvailableFunctions, TEXT(", "));
+		return CreateErrorResponse(FString::Printf(
+			TEXT("Factory function not found on class '%s'. Available static functions: [%s]"),
+			*AsyncClass->GetName(), *AvailableStr));
+	}
+
+	// Spawn the UK2Node_AsyncAction using the public InitializeProxyFromFunction API
+	UK2Node_AsyncAction* AsyncNode = FEdGraphSchemaAction_K2NewNode::SpawnNode<UK2Node_AsyncAction>(
+		TargetGraph,
+		Position,
+		EK2NewNodeFlags::None,
+		[FactoryFunction](UK2Node_AsyncAction* Node)
+		{
+			Node->InitializeProxyFromFunction(FactoryFunction);
+		}
+	);
+
+	if (!AsyncNode)
+	{
+		return CreateErrorResponse(TEXT("Failed to create async action node"));
+	}
+
+	// Set pin defaults if provided
+	const TSharedPtr<FJsonObject>* PinDefaults = nullptr;
+	if (Params->TryGetObjectField(TEXT("pin_defaults"), PinDefaults) && PinDefaults && (*PinDefaults).IsValid())
+	{
+		for (const auto& Pair : (*PinDefaults)->Values)
+		{
+			UEdGraphPin* Pin = FMCPCommonUtils::FindPin(AsyncNode, Pair.Key, EGPD_Input);
+			if (Pin)
+			{
+				FString Value = Pair.Value->AsString();
+				Pin->DefaultValue = Value;
+			}
+		}
+	}
+
+	MarkBlueprintModified(Blueprint, Context);
+	RegisterCreatedNode(AsyncNode, Context);
+
+	// Build response with all pin info
+	TSharedPtr<FJsonObject> ResultData = MakeShared<FJsonObject>();
+	ResultData->SetStringField(TEXT("node_id"), AsyncNode->NodeGuid.ToString());
+	ResultData->SetStringField(TEXT("class_name"), AsyncClass->GetName());
+	ResultData->SetStringField(TEXT("factory_function"), FactoryFunction->GetName());
+
+	TArray<TSharedPtr<FJsonValue>> PinsArray;
+	for (UEdGraphPin* Pin : AsyncNode->Pins)
+	{
+		if (Pin && !Pin->bHidden)
+		{
+			TSharedPtr<FJsonObject> PinObj = MakeShared<FJsonObject>();
+			PinObj->SetStringField(TEXT("name"), Pin->PinName.ToString());
+			PinObj->SetStringField(TEXT("direction"), Pin->Direction == EGPD_Input ? TEXT("input") : TEXT("output"));
+			PinObj->SetStringField(TEXT("type"), Pin->PinType.PinCategory.ToString());
+			if (!Pin->DefaultValue.IsEmpty())
+			{
+				PinObj->SetStringField(TEXT("default_value"), Pin->DefaultValue);
+			}
+			PinsArray.Add(MakeShared<FJsonValueObject>(PinObj));
+		}
+	}
+	ResultData->SetArrayField(TEXT("pins"), PinsArray);
+
+	return CreateSuccessResponse(ResultData);
+}
+
+
+// ============================================================================
+// Self-Evolution: Dynamic Node Discovery & Creation
+// ============================================================================
+
+// Spawner cache — maps string IDs to weak pointers for add_generic_node
+namespace SelfEvolution
+{
+	static TMap<FString, TWeakObjectPtr<UBlueprintNodeSpawner>> SpawnerCache;
+	static int32 NextSpawnerId = 0;
+
+	static FString CacheSpawner(UBlueprintNodeSpawner* Spawner)
+	{
+		// Return existing ID if already cached
+		for (const auto& Pair : SpawnerCache)
+		{
+			if (Pair.Value.Get() == Spawner)
+				return Pair.Key;
+		}
+		FString Id = FString::Printf(TEXT("sp_%d"), NextSpawnerId++);
+		SpawnerCache.Add(Id, Spawner);
+		return Id;
+	}
+
+	static UBlueprintNodeSpawner* LookupSpawner(const FString& SpawnerId)
+	{
+		auto* Found = SpawnerCache.Find(SpawnerId);
+		if (Found && Found->IsValid())
+			return Found->Get();
+		return nullptr;
+	}
+
+	static void CleanCache()
+	{
+		TArray<FString> Expired;
+		for (const auto& Pair : SpawnerCache)
+		{
+			if (!Pair.Value.IsValid())
+				Expired.Add(Pair.Key);
+		}
+		for (const FString& Key : Expired)
+			SpawnerCache.Remove(Key);
+
+		// Hard limit to prevent unbounded growth
+		if (SpawnerCache.Num() > 5000)
+		{
+			SpawnerCache.Empty();
+			NextSpawnerId = 0;
+		}
+	}
+}
+
+// --- search_catalog ---
+
+bool FSearchCatalogAction::Validate(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context, FString& OutError)
+{
+	FString Keyword;
+	if (!GetRequiredString(Params, TEXT("keyword"), Keyword, OutError)) return false;
+	if (Keyword.Len() < 2)
+	{
+		OutError = TEXT("keyword must be at least 2 characters");
+		return false;
+	}
+	return true;
+}
+
+TSharedPtr<FJsonObject> FSearchCatalogAction::ExecuteInternal(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context)
+{
+	FString Keyword = Params->GetStringField(TEXT("keyword"));
+	int32 MaxResults = (int32)GetOptionalNumber(Params, TEXT("max_results"), 50.0);
+	FString CategoryFilter = GetOptionalString(Params, TEXT("category"));
+	MaxResults = FMath::Clamp(MaxResults, 1, 200);
+
+	SelfEvolution::CleanCache();
+
+	FBlueprintActionDatabase& DB = FBlueprintActionDatabase::Get();
+	FBlueprintActionDatabase::FActionRegistry const& AllActions = DB.GetAllActions();
+
+	TArray<TSharedPtr<FJsonValue>> Results;
+	FString KeywordLower = Keyword.ToLower();
+	FString CategoryLower = CategoryFilter.ToLower();
+
+	for (const auto& Pair : AllActions)
+	{
+		const FBlueprintActionDatabase::FActionList& SpawnerList = Pair.Value;
+
+		for (int32 i = 0; i < SpawnerList.Num(); ++i)
+		{
+			UBlueprintNodeSpawner* Spawner = SpawnerList[i];
+			if (!Spawner || !Spawner->NodeClass)
+				continue;
+
+			// Get UI spec (uses cached template if already primed)
+			FBlueprintActionUiSpec const& UiSpec = Spawner->PrimeDefaultUiSpec();
+
+			FString MenuName = UiSpec.MenuName.ToString();
+			if (MenuName.IsEmpty())
+				continue; // Skip hidden/internal actions
+
+			FString Category = UiSpec.Category.ToString();
+			FString Keywords = UiSpec.Keywords.ToString();
+
+			// Keyword match (case insensitive)
+			bool bMatch = MenuName.ToLower().Contains(KeywordLower)
+				|| Category.ToLower().Contains(KeywordLower)
+				|| Keywords.ToLower().Contains(KeywordLower);
+
+			if (!bMatch)
+				continue;
+
+			// Category filter
+			if (!CategoryLower.IsEmpty() && !Category.ToLower().Contains(CategoryLower))
+				continue;
+
+			// Cache the spawner for later use with add_generic
+			FString SpawnerId = SelfEvolution::CacheSpawner(Spawner);
+
+			// Build result item
+			TSharedPtr<FJsonObject> Item = MakeShared<FJsonObject>();
+			Item->SetStringField(TEXT("spawner_id"), SpawnerId);
+			Item->SetStringField(TEXT("name"), MenuName);
+			Item->SetStringField(TEXT("category"), Category);
+			Item->SetStringField(TEXT("node_class"), Spawner->NodeClass->GetName());
+			if (!Keywords.IsEmpty())
+				Item->SetStringField(TEXT("keywords"), Keywords);
+			if (!UiSpec.Tooltip.IsEmpty())
+				Item->SetStringField(TEXT("tooltip"), UiSpec.Tooltip.ToString());
+
+			Results.Add(MakeShared<FJsonValueObject>(Item));
+			if (Results.Num() >= MaxResults)
+				break;
+		}
+		if (Results.Num() >= MaxResults)
+			break;
+	}
+
+	TSharedPtr<FJsonObject> ResultData = MakeShared<FJsonObject>();
+	ResultData->SetArrayField(TEXT("results"), Results);
+	ResultData->SetNumberField(TEXT("count"), (double)Results.Num());
+	return CreateSuccessResponse(ResultData);
+}
+
+
+// --- add_generic_node ---
+
+bool FAddGenericNodeAction::Validate(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context, FString& OutError)
+{
+	FString SpawnerId;
+	if (!GetRequiredString(Params, TEXT("spawner_id"), SpawnerId, OutError)) return false;
+	return ValidateGraph(Params, Context, OutError);
+}
+
+TSharedPtr<FJsonObject> FAddGenericNodeAction::ExecuteInternal(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context)
+{
+	FString SpawnerId = Params->GetStringField(TEXT("spawner_id"));
+	FVector2D Position = GetNodePosition(Params);
+
+	UBlueprintNodeSpawner* Spawner = SelfEvolution::LookupSpawner(SpawnerId);
+	if (!Spawner)
+	{
+		return CreateErrorResponse(TEXT("Spawner not found or expired. Run node.search_catalog again to get a fresh spawner_id."));
+	}
+
+	UBlueprint* Blueprint = GetTargetBlueprint(Params, Context);
+	UEdGraph* TargetGraph = GetTargetGraph(Params, Context);
+
+	if (!Blueprint || !TargetGraph)
+		return CreateErrorResponse(TEXT("Blueprint or graph not found"));
+
+	// Spawn the node using the universal UBlueprintNodeSpawner::Invoke API
+	IBlueprintNodeBinder::FBindingSet EmptyBindings;
+	UEdGraphNode* NewNode = Spawner->Invoke(TargetGraph, EmptyBindings, Position);
+
+	if (!NewNode)
+		return CreateErrorResponse(TEXT("Failed to spawn node. The spawner may not be compatible with this graph type."));
+
+	// Set pin defaults if provided
+	const TSharedPtr<FJsonObject>* PinDefaults = nullptr;
+	if (Params->TryGetObjectField(TEXT("pin_defaults"), PinDefaults) && PinDefaults && (*PinDefaults).IsValid())
+	{
+		for (const auto& PinPair : (*PinDefaults)->Values)
+		{
+			UEdGraphPin* Pin = FMCPCommonUtils::FindPin(NewNode, PinPair.Key, EGPD_Input);
+			if (Pin)
+			{
+				Pin->DefaultValue = PinPair.Value->AsString();
+			}
+		}
+	}
+
+	MarkBlueprintModified(Blueprint, Context);
+	RegisterCreatedNode(NewNode, Context);
+
+	// Build response with node info and all pins
+	TSharedPtr<FJsonObject> ResultData = MakeShared<FJsonObject>();
+	ResultData->SetStringField(TEXT("node_id"), NewNode->NodeGuid.ToString());
+	ResultData->SetStringField(TEXT("node_class"), NewNode->GetClass()->GetName());
+	ResultData->SetStringField(TEXT("node_title"), NewNode->GetNodeTitle(ENodeTitleType::FullTitle).ToString());
+
+	TArray<TSharedPtr<FJsonValue>> PinsArray;
+	for (UEdGraphPin* Pin : NewNode->Pins)
+	{
+		if (Pin && !Pin->bHidden)
+		{
+			TSharedPtr<FJsonObject> PinObj = MakeShared<FJsonObject>();
+			PinObj->SetStringField(TEXT("name"), Pin->PinName.ToString());
+			PinObj->SetStringField(TEXT("direction"), Pin->Direction == EGPD_Input ? TEXT("input") : TEXT("output"));
+			PinObj->SetStringField(TEXT("type"), Pin->PinType.PinCategory.ToString());
+			if (!Pin->DefaultValue.IsEmpty())
+			{
+				PinObj->SetStringField(TEXT("default_value"), Pin->DefaultValue);
+			}
+			PinsArray.Add(MakeShared<FJsonValueObject>(PinObj));
+		}
+	}
+	ResultData->SetArrayField(TEXT("pins"), PinsArray);
+
+	return CreateSuccessResponse(ResultData);
+}
+
+
+// --- suggest_next ---
+
+bool FSuggestNextAction::Validate(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context, FString& OutError)
+{
+	FString NodeId, PinName;
+	if (!GetRequiredString(Params, TEXT("node_id"), NodeId, OutError)) return false;
+	if (!GetRequiredString(Params, TEXT("pin_name"), PinName, OutError)) return false;
+	return ValidateGraph(Params, Context, OutError);
+}
+
+TSharedPtr<FJsonObject> FSuggestNextAction::ExecuteInternal(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context)
+{
+	FString NodeIdStr = Params->GetStringField(TEXT("node_id"));
+	FString PinName = Params->GetStringField(TEXT("pin_name"));
+	int32 MaxResults = (int32)GetOptionalNumber(Params, TEXT("max_results"), 30.0);
+	MaxResults = FMath::Clamp(MaxResults, 1, 100);
+
+	UBlueprint* Blueprint = GetTargetBlueprint(Params, Context);
+	UEdGraph* TargetGraph = GetTargetGraph(Params, Context);
+
+	if (!Blueprint || !TargetGraph)
+		return CreateErrorResponse(TEXT("Blueprint or graph not found"));
+
+	// Find the node by GUID
+	FGuid NodeGuid;
+	if (!FGuid::Parse(NodeIdStr, NodeGuid))
+		return CreateErrorResponse(TEXT("Invalid node_id format. Expected a GUID string."));
+
+	UEdGraphNode* SourceNode = nullptr;
+	for (UEdGraphNode* Node : TargetGraph->Nodes)
+	{
+		if (Node && Node->NodeGuid == NodeGuid)
+		{
+			SourceNode = Node;
+			break;
+		}
+	}
+	if (!SourceNode)
+		return CreateErrorResponse(FString::Printf(TEXT("Node '%s' not found in graph"), *NodeIdStr));
+
+	// Find the pin by name
+	UEdGraphPin* SourcePin = nullptr;
+	for (UEdGraphPin* Pin : SourceNode->Pins)
+	{
+		if (Pin && Pin->PinName.ToString() == PinName)
+		{
+			SourcePin = Pin;
+			break;
+		}
+	}
+	if (!SourcePin)
+	{
+		// List available pins for helpful error
+		TArray<FString> PinNames;
+		for (UEdGraphPin* Pin : SourceNode->Pins)
+		{
+			if (Pin && !Pin->bHidden)
+				PinNames.Add(Pin->PinName.ToString());
+		}
+		return CreateErrorResponse(FString::Printf(
+			TEXT("Pin '%s' not found. Available pins: [%s]"),
+			*PinName, *FString::Join(PinNames, TEXT(", "))));
+	}
+
+	// Build context for context-sensitive action menu
+	FBlueprintActionContext FilterContext;
+	FilterContext.Blueprints.Add(Blueprint);
+	FilterContext.Graphs.Add(TargetGraph);
+	FilterContext.Pins.Add(SourcePin);
+
+	// Build context menu using UE's native system (synchronous, no time-slicing)
+	FBlueprintActionMenuBuilder MenuBuilder;
+	FBlueprintActionMenuUtils::MakeContextMenu(
+		FilterContext,
+		/*bIsContextSensitive=*/ true,
+		/*ClassTargetMask=*/ 0,
+		MenuBuilder
+	);
+
+	// Iterate results and build response
+	SelfEvolution::CleanCache();
+	TArray<TSharedPtr<FJsonValue>> Results;
+
+	int32 NumActions = MenuBuilder.GetNumActions();
+	for (int32 i = 0; i < NumActions && Results.Num() < MaxResults; ++i)
+	{
+		TSharedPtr<FEdGraphSchemaAction> Action = MenuBuilder.GetSchemaAction(i);
+		if (!Action.IsValid())
+			continue;
+
+		FString MenuName = Action->GetMenuDescription().ToString();
+		if (MenuName.IsEmpty())
+			continue;
+
+		TSharedPtr<FJsonObject> Item = MakeShared<FJsonObject>();
+		Item->SetStringField(TEXT("name"), MenuName);
+		Item->SetStringField(TEXT("category"), Action->GetCategory().ToString());
+
+		// If it's a FBlueprintActionMenuItem, extract spawner info and cache it
+		if (Action->GetTypeId() == FBlueprintActionMenuItem::StaticGetTypeId())
+		{
+			FBlueprintActionMenuItem* MenuItem = static_cast<FBlueprintActionMenuItem*>(Action.Get());
+			UBlueprintNodeSpawner const* RawSpawner = MenuItem->GetRawAction();
+			if (RawSpawner)
+			{
+				Item->SetStringField(TEXT("node_class"),
+					RawSpawner->NodeClass ? RawSpawner->NodeClass->GetName() : TEXT("Unknown"));
+
+				// Cache spawner for add_generic (const_cast is safe: database owns as non-const)
+				UBlueprintNodeSpawner* MutableSpawner = const_cast<UBlueprintNodeSpawner*>(RawSpawner);
+				FString SpawnerId = SelfEvolution::CacheSpawner(MutableSpawner);
+				Item->SetStringField(TEXT("spawner_id"), SpawnerId);
+			}
+		}
+
+		Results.Add(MakeShared<FJsonValueObject>(Item));
+	}
+
+	TSharedPtr<FJsonObject> ResultData = MakeShared<FJsonObject>();
+	ResultData->SetArrayField(TEXT("compatible_actions"), Results);
+	ResultData->SetNumberField(TEXT("count"), (double)Results.Num());
+	ResultData->SetNumberField(TEXT("total_available"), (double)NumActions);
+	ResultData->SetStringField(TEXT("source_pin"), PinName);
+	ResultData->SetStringField(TEXT("pin_direction"),
+		SourcePin->Direction == EGPD_Input ? TEXT("input") : TEXT("output"));
+	ResultData->SetStringField(TEXT("pin_type"), SourcePin->PinType.PinCategory.ToString());
+
 	return CreateSuccessResponse(ResultData);
 }

--- a/Source/UEEditorMCP/Private/Actions/NodeActions.cpp
+++ b/Source/UEEditorMCP/Private/Actions/NodeActions.cpp
@@ -5548,11 +5548,15 @@ TSharedPtr<FJsonObject> FSearchCatalogAction::ExecuteInternal(const TSharedPtr<F
 
 			FString Category = UiSpec.Category.ToString();
 			FString Keywords = UiSpec.Keywords.ToString();
+			FString Tooltip = UiSpec.Tooltip.ToString();
+			FString NodeClassName = Spawner->NodeClass ? Spawner->NodeClass->GetName() : TEXT("");
 
-			// Keyword match (case insensitive)
+			// Keyword match (case insensitive) — searches MenuName, Category, Keywords, Tooltip, and NodeClass name
 			bool bMatch = MenuName.ToLower().Contains(KeywordLower)
 				|| Category.ToLower().Contains(KeywordLower)
-				|| Keywords.ToLower().Contains(KeywordLower);
+				|| Keywords.ToLower().Contains(KeywordLower)
+				|| Tooltip.ToLower().Contains(KeywordLower)
+				|| NodeClassName.ToLower().Contains(KeywordLower);
 
 			if (!bMatch)
 				continue;
@@ -5623,18 +5627,47 @@ TSharedPtr<FJsonObject> FAddGenericNodeAction::ExecuteInternal(const TSharedPtr<
 	if (!NewNode)
 		return CreateErrorResponse(TEXT("Failed to spawn node. The spawner may not be compatible with this graph type."));
 
-	// Set pin defaults if provided
+	// Set pin defaults if provided — use Schema API for proper notifications
 	const TSharedPtr<FJsonObject>* PinDefaults = nullptr;
 	if (Params->TryGetObjectField(TEXT("pin_defaults"), PinDefaults) && PinDefaults && (*PinDefaults).IsValid())
 	{
+		const UEdGraphSchema_K2* K2Schema = GetDefault<UEdGraphSchema_K2>();
 		for (const auto& PinPair : (*PinDefaults)->Values)
 		{
 			UEdGraphPin* Pin = FMCPCommonUtils::FindPin(NewNode, PinPair.Key, EGPD_Input);
-			if (Pin)
+			if (!Pin) continue;
+
+			FString Value = PinPair.Value->AsString();
+			const FName& PinCategory = Pin->PinType.PinCategory;
+
+			// Handle object/class pins via TrySetDefaultObject
+			if (PinCategory == UEdGraphSchema_K2::PC_Object ||
+				PinCategory == UEdGraphSchema_K2::PC_Class ||
+				PinCategory == UEdGraphSchema_K2::PC_SoftObject ||
+				PinCategory == UEdGraphSchema_K2::PC_SoftClass)
 			{
-				Pin->DefaultValue = PinPair.Value->AsString();
+				if (!Value.IsEmpty())
+				{
+					UObject* Obj = StaticLoadObject(UObject::StaticClass(), nullptr, *Value);
+					if (Obj)
+					{
+						K2Schema->TrySetDefaultObject(*Pin, Obj);
+					}
+					else
+					{
+						Pin->DefaultValue = Value;
+					}
+				}
+			}
+			else
+			{
+				// Use schema to set default — triggers proper pin notifications
+				K2Schema->TrySetDefaultValue(*Pin, Value);
 			}
 		}
+		// Some nodes need reconstruction after pin defaults change
+		NewNode->ReconstructNode();
+		TargetGraph->NotifyGraphChanged();
 	}
 
 	MarkBlueprintModified(Blueprint, Context);

--- a/Source/UEEditorMCP/Private/Actions/UMGActions.cpp
+++ b/Source/UEEditorMCP/Private/Actions/UMGActions.cpp
@@ -186,6 +186,45 @@ static void ApplyCanvasSlot(UCanvasPanelSlot* Slot, const TSharedPtr<FJsonObject
 }
 
 /**
+ * If "parent" parameter is present, reparent the newly created widget
+ * from the root canvas into the specified parent container.
+ * Returns true on success (or if no parent specified). Sets OutError on failure.
+ */
+static bool TryReparentToParent(UWidgetBlueprint* WidgetBlueprint, UWidget* NewWidget,
+	const TSharedPtr<FJsonObject>& Params, FString& OutError)
+{
+	FString ParentName;
+	if (!Params->TryGetStringField(TEXT("parent"), ParentName) || ParentName.IsEmpty())
+	{
+		return true; // No parent specified, keep in root canvas
+	}
+
+	UWidget* ParentWidget = WidgetBlueprint->WidgetTree->FindWidget(FName(*ParentName));
+	if (!ParentWidget)
+	{
+		OutError = FString::Printf(TEXT("Parent widget '%s' not found"), *ParentName);
+		return false;
+	}
+
+	UPanelWidget* ParentPanel = Cast<UPanelWidget>(ParentWidget);
+	if (!ParentPanel)
+	{
+		OutError = FString::Printf(TEXT("Parent '%s' is not a container widget"), *ParentName);
+		return false;
+	}
+
+	NewWidget->RemoveFromParent();
+	UPanelSlot* NewSlot = ParentPanel->AddChild(NewWidget);
+	if (!NewSlot)
+	{
+		OutError = FString::Printf(TEXT("Failed to add widget as child of '%s'"), *ParentName);
+		return false;
+	}
+
+	return true;
+}
+
+/**
  * Repair: populate WidgetVariableNameToGuidMap for any widget missing a GUID entry.
  *
  * Root cause (WBP_DanmakuLayer / WBP_DanmakuItem, 2026-02-19):
@@ -652,6 +691,15 @@ TSharedPtr<FJsonObject> FAddImageToWidgetAction::ExecuteInternal(const TSharedPt
 		ApplyCanvasSlot(ImageSlot, Params);
 	}
 
+	// Optional: reparent into a specified parent container
+	{
+		FString ReparentError;
+		if (!TryReparentToParent(WidgetBlueprint, Image, Params, ReparentError))
+		{
+			return FMCPCommonUtils::CreateErrorResponse(ReparentError);
+		}
+	}
+
 	// Mark modified, compile, and refresh the Widget Designer
 	WidgetBlueprint->MarkPackageDirty();
 	MarkWidgetBlueprintDirty(WidgetBlueprint, Context);
@@ -718,6 +766,16 @@ TSharedPtr<FJsonObject> FAddBorderToWidgetAction::ExecuteInternal(const TSharedP
 	UCanvasPanelSlot* Slot = RootCanvas->AddChildToCanvas(Border);
 	ApplyCanvasSlot(Slot, Params);
 
+	// Optional: reparent into a specified parent container
+	if (Slot && Slot->Content)
+	{
+		FString ReparentError;
+		if (!TryReparentToParent(WidgetBlueprint, Slot->Content, Params, ReparentError))
+		{
+			return FMCPCommonUtils::CreateErrorResponse(ReparentError);
+		}
+	}
+
 	WidgetBlueprint->MarkPackageDirty();
 	MarkWidgetBlueprintDirty(WidgetBlueprint, Context);
 
@@ -772,6 +830,16 @@ TSharedPtr<FJsonObject> FAddOverlayToWidgetAction::ExecuteInternal(const TShared
 
 	UCanvasPanelSlot* Slot = RootCanvas->AddChildToCanvas(Overlay);
 	ApplyCanvasSlot(Slot, Params);
+
+	// Optional: reparent into a specified parent container
+	if (Slot && Slot->Content)
+	{
+		FString ReparentError;
+		if (!TryReparentToParent(WidgetBlueprint, Slot->Content, Params, ReparentError))
+		{
+			return FMCPCommonUtils::CreateErrorResponse(ReparentError);
+		}
+	}
 
 	WidgetBlueprint->MarkPackageDirty();
 	MarkWidgetBlueprintDirty(WidgetBlueprint, Context);
@@ -828,6 +896,16 @@ TSharedPtr<FJsonObject> FAddHorizontalBoxToWidgetAction::ExecuteInternal(const T
 	UCanvasPanelSlot* Slot = RootCanvas->AddChildToCanvas(HorizontalBox);
 	ApplyCanvasSlot(Slot, Params);
 
+	// Optional: reparent into a specified parent container
+	if (Slot && Slot->Content)
+	{
+		FString ReparentError;
+		if (!TryReparentToParent(WidgetBlueprint, Slot->Content, Params, ReparentError))
+		{
+			return FMCPCommonUtils::CreateErrorResponse(ReparentError);
+		}
+	}
+
 	WidgetBlueprint->MarkPackageDirty();
 	MarkWidgetBlueprintDirty(WidgetBlueprint, Context);
 
@@ -882,6 +960,16 @@ TSharedPtr<FJsonObject> FAddVerticalBoxToWidgetAction::ExecuteInternal(const TSh
 
 	UCanvasPanelSlot* Slot = RootCanvas->AddChildToCanvas(VerticalBox);
 	ApplyCanvasSlot(Slot, Params);
+
+	// Optional: reparent into a specified parent container
+	if (Slot && Slot->Content)
+	{
+		FString ReparentError;
+		if (!TryReparentToParent(WidgetBlueprint, Slot->Content, Params, ReparentError))
+		{
+			return FMCPCommonUtils::CreateErrorResponse(ReparentError);
+		}
+	}
 
 	WidgetBlueprint->MarkPackageDirty();
 	MarkWidgetBlueprintDirty(WidgetBlueprint, Context);
@@ -943,6 +1031,16 @@ TSharedPtr<FJsonObject> FAddSliderToWidgetAction::ExecuteInternal(const TSharedP
 
 	UCanvasPanelSlot* Slot = RootCanvas->AddChildToCanvas(Slider);
 	ApplyCanvasSlot(Slot, Params);
+
+	// Optional: reparent into a specified parent container
+	if (Slot && Slot->Content)
+	{
+		FString ReparentError;
+		if (!TryReparentToParent(WidgetBlueprint, Slot->Content, Params, ReparentError))
+		{
+			return FMCPCommonUtils::CreateErrorResponse(ReparentError);
+		}
+	}
 
 	WidgetBlueprint->MarkPackageDirty();
 	MarkWidgetBlueprintDirty(WidgetBlueprint, Context);
@@ -1011,6 +1109,16 @@ TSharedPtr<FJsonObject> FAddProgressBarToWidgetAction::ExecuteInternal(const TSh
 	UCanvasPanelSlot* Slot = RootCanvas->AddChildToCanvas(ProgressBar);
 	ApplyCanvasSlot(Slot, Params);
 
+	// Optional: reparent into a specified parent container
+	if (Slot && Slot->Content)
+	{
+		FString ReparentError;
+		if (!TryReparentToParent(WidgetBlueprint, Slot->Content, Params, ReparentError))
+		{
+			return FMCPCommonUtils::CreateErrorResponse(ReparentError);
+		}
+	}
+
 	WidgetBlueprint->MarkPackageDirty();
 	MarkWidgetBlueprintDirty(WidgetBlueprint, Context);
 
@@ -1073,6 +1181,16 @@ TSharedPtr<FJsonObject> FAddSizeBoxToWidgetAction::ExecuteInternal(const TShared
 	UCanvasPanelSlot* Slot = RootCanvas->AddChildToCanvas(SizeBox);
 	ApplyCanvasSlot(Slot, Params);
 
+	// Optional: reparent into a specified parent container
+	if (Slot && Slot->Content)
+	{
+		FString ReparentError;
+		if (!TryReparentToParent(WidgetBlueprint, Slot->Content, Params, ReparentError))
+		{
+			return FMCPCommonUtils::CreateErrorResponse(ReparentError);
+		}
+	}
+
 	WidgetBlueprint->MarkPackageDirty();
 	MarkWidgetBlueprintDirty(WidgetBlueprint, Context);
 
@@ -1128,6 +1246,16 @@ TSharedPtr<FJsonObject> FAddScaleBoxToWidgetAction::ExecuteInternal(const TShare
 	UCanvasPanelSlot* Slot = RootCanvas->AddChildToCanvas(ScaleBox);
 	ApplyCanvasSlot(Slot, Params);
 
+	// Optional: reparent into a specified parent container
+	if (Slot && Slot->Content)
+	{
+		FString ReparentError;
+		if (!TryReparentToParent(WidgetBlueprint, Slot->Content, Params, ReparentError))
+		{
+			return FMCPCommonUtils::CreateErrorResponse(ReparentError);
+		}
+	}
+
 	WidgetBlueprint->MarkPackageDirty();
 	MarkWidgetBlueprintDirty(WidgetBlueprint, Context);
 
@@ -1182,6 +1310,16 @@ TSharedPtr<FJsonObject> FAddCanvasPanelToWidgetAction::ExecuteInternal(const TSh
 
 	UCanvasPanelSlot* Slot = RootCanvas->AddChildToCanvas(CanvasPanel);
 	ApplyCanvasSlot(Slot, Params);
+
+	// Optional: reparent into a specified parent container
+	if (Slot && Slot->Content)
+	{
+		FString ReparentError;
+		if (!TryReparentToParent(WidgetBlueprint, Slot->Content, Params, ReparentError))
+		{
+			return FMCPCommonUtils::CreateErrorResponse(ReparentError);
+		}
+	}
 
 	WidgetBlueprint->MarkPackageDirty();
 	MarkWidgetBlueprintDirty(WidgetBlueprint, Context);
@@ -1259,6 +1397,16 @@ TSharedPtr<FJsonObject> FAddComboBoxToWidgetAction::ExecuteInternal(const TShare
 	UCanvasPanelSlot* Slot = RootCanvas->AddChildToCanvas(ComboBox);
 	ApplyCanvasSlot(Slot, Params);
 
+	// Optional: reparent into a specified parent container
+	if (Slot && Slot->Content)
+	{
+		FString ReparentError;
+		if (!TryReparentToParent(WidgetBlueprint, Slot->Content, Params, ReparentError))
+		{
+			return FMCPCommonUtils::CreateErrorResponse(ReparentError);
+		}
+	}
+
 	WidgetBlueprint->MarkPackageDirty();
 	MarkWidgetBlueprintDirty(WidgetBlueprint, Context);
 
@@ -1332,6 +1480,16 @@ TSharedPtr<FJsonObject> FAddCheckBoxToWidgetAction::ExecuteInternal(const TShare
 
 	UCanvasPanelSlot* Slot = RootCanvas->AddChildToCanvas(CheckBox);
 	ApplyCanvasSlot(Slot, Params);
+
+	// Optional: reparent into a specified parent container
+	if (Slot && Slot->Content)
+	{
+		FString ReparentError;
+		if (!TryReparentToParent(WidgetBlueprint, Slot->Content, Params, ReparentError))
+		{
+			return FMCPCommonUtils::CreateErrorResponse(ReparentError);
+		}
+	}
 
 	WidgetBlueprint->MarkPackageDirty();
 	MarkWidgetBlueprintDirty(WidgetBlueprint, Context);
@@ -1412,6 +1570,16 @@ TSharedPtr<FJsonObject> FAddSpinBoxToWidgetAction::ExecuteInternal(const TShared
 	UCanvasPanelSlot* Slot = RootCanvas->AddChildToCanvas(SpinBox);
 	ApplyCanvasSlot(Slot, Params);
 
+	// Optional: reparent into a specified parent container
+	if (Slot && Slot->Content)
+	{
+		FString ReparentError;
+		if (!TryReparentToParent(WidgetBlueprint, Slot->Content, Params, ReparentError))
+		{
+			return FMCPCommonUtils::CreateErrorResponse(ReparentError);
+		}
+	}
+
 	WidgetBlueprint->MarkPackageDirty();
 	MarkWidgetBlueprintDirty(WidgetBlueprint, Context);
 
@@ -1484,6 +1652,16 @@ TSharedPtr<FJsonObject> FAddEditableTextBoxToWidgetAction::ExecuteInternal(const
 
 	UCanvasPanelSlot* Slot = RootCanvas->AddChildToCanvas(TextBox);
 	ApplyCanvasSlot(Slot, Params);
+
+	// Optional: reparent into a specified parent container
+	if (Slot && Slot->Content)
+	{
+		FString ReparentError;
+		if (!TryReparentToParent(WidgetBlueprint, Slot->Content, Params, ReparentError))
+		{
+			return FMCPCommonUtils::CreateErrorResponse(ReparentError);
+		}
+	}
 
 	WidgetBlueprint->MarkPackageDirty();
 	MarkWidgetBlueprintDirty(WidgetBlueprint, Context);
@@ -3309,6 +3487,16 @@ TSharedPtr<FJsonObject> FAddGenericWidgetAction::ExecuteInternal(const TSharedPt
 	UCanvasPanelSlot* Slot = RootCanvas->AddChildToCanvas(NewWidget);
 	ApplyCanvasSlot(Slot, Params);
 
+	// Optional: reparent into a specified parent container
+	if (Slot && Slot->Content)
+	{
+		FString ReparentError;
+		if (!TryReparentToParent(WidgetBlueprint, Slot->Content, Params, ReparentError))
+		{
+			return FMCPCommonUtils::CreateErrorResponse(ReparentError);
+		}
+	}
+
 	WidgetBlueprint->MarkPackageDirty();
 	MarkWidgetBlueprintDirty(WidgetBlueprint, Context);
 
@@ -4011,5 +4199,69 @@ TSharedPtr<FJsonObject> FMVVMRemoveViewModelAction::ExecuteInternal(const TShare
 	ResultObj->SetBoolField(TEXT("success"), true);
 	ResultObj->SetStringField(TEXT("removed_viewmodel_name"), ViewModelName);
 	ResultObj->SetStringField(TEXT("removed_viewmodel_id"), TargetId.ToString());
+	return ResultObj;
+}
+
+
+// ============================================================================
+// Set bIsVariable on a widget component
+// ============================================================================
+
+bool FSetWidgetIsVariableAction::Validate(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context, FString& OutError)
+{
+	FString WidgetBPName, TargetName;
+	if (!GetRequiredString(Params, TEXT("widget_name"), WidgetBPName, OutError)) return false;
+	if (!GetRequiredString(Params, TEXT("target"), TargetName, OutError)) return false;
+	return true;
+}
+
+TSharedPtr<FJsonObject> FSetWidgetIsVariableAction::ExecuteInternal(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context)
+{
+	FString WidgetBPName = Params->GetStringField(TEXT("widget_name"));
+	FString TargetName = Params->GetStringField(TEXT("target"));
+	bool bIsVariable = true;
+	if (Params->HasField(TEXT("is_variable")))
+	{
+		bIsVariable = Params->GetBoolField(TEXT("is_variable"));
+	}
+
+	UWidgetBlueprint* WidgetBlueprint = FindWidgetBlueprintByName(WidgetBPName);
+	if (!WidgetBlueprint)
+	{
+		return FMCPCommonUtils::CreateErrorResponse(FString::Printf(
+			TEXT("Widget Blueprint '%s' not found"), *WidgetBPName));
+	}
+
+	if (!WidgetBlueprint->WidgetTree)
+	{
+		return FMCPCommonUtils::CreateErrorResponse(TEXT("Widget Blueprint has no WidgetTree"));
+	}
+
+	// Find the target widget
+	UWidget* TargetWidget = nullptr;
+	WidgetBlueprint->WidgetTree->ForEachWidget([&](UWidget* Widget)
+	{
+		if (Widget && Widget->GetName() == TargetName)
+		{
+			TargetWidget = Widget;
+		}
+	});
+
+	if (!TargetWidget)
+	{
+		return FMCPCommonUtils::CreateErrorResponse(FString::Printf(
+			TEXT("Widget '%s' not found in '%s'"), *TargetName, *WidgetBPName));
+	}
+
+	TargetWidget->bIsVariable = bIsVariable;
+
+	WidgetBlueprint->MarkPackageDirty();
+	MarkWidgetBlueprintDirty(WidgetBlueprint, Context);
+
+	TSharedPtr<FJsonObject> ResultObj = MakeShared<FJsonObject>();
+	ResultObj->SetStringField(TEXT("widget_name"), WidgetBPName);
+	ResultObj->SetStringField(TEXT("target"), TargetName);
+	ResultObj->SetBoolField(TEXT("is_variable"), bIsVariable);
+	ResultObj->SetBoolField(TEXT("success"), true);
 	return ResultObj;
 }

--- a/Source/UEEditorMCP/Private/MCPBridge.cpp
+++ b/Source/UEEditorMCP/Private/MCPBridge.cpp
@@ -177,6 +177,18 @@ void UMCPBridge::RegisterActions()
 	ActionHandlers.Add(TEXT("call_blueprint_function"), MakeShared<FCallBlueprintFunctionAction>());
 
 	// =========================================================================
+	// Node Actions - Async Action Nodes (Third-party plugin support)
+	// =========================================================================
+	ActionHandlers.Add(TEXT("add_async_action_node"), MakeShared<FAddAsyncActionNodeAction>());
+
+	// =========================================================================
+	// Self-Evolution: Dynamic Node Discovery & Creation
+	// =========================================================================
+	ActionHandlers.Add(TEXT("search_catalog"), MakeShared<FSearchCatalogAction>());
+	ActionHandlers.Add(TEXT("add_generic_node"), MakeShared<FAddGenericNodeAction>());
+	ActionHandlers.Add(TEXT("suggest_next"), MakeShared<FSuggestNextAction>());
+
+	// =========================================================================
 	// Node Actions - External Object Property Nodes
 	// =========================================================================
 	ActionHandlers.Add(TEXT("set_object_property"), MakeShared<FSetObjectPropertyAction>());
@@ -287,6 +299,9 @@ void UMCPBridge::RegisterActions()
 	ActionHandlers.Add(TEXT("mvvm_get_bindings"), MakeShared<FMVVMGetBindingsAction>());
 	ActionHandlers.Add(TEXT("mvvm_remove_binding"), MakeShared<FMVVMRemoveBindingAction>());
 	ActionHandlers.Add(TEXT("mvvm_remove_viewmodel"), MakeShared<FMVVMRemoveViewModelAction>());
+
+	// Widget Is Variable
+	ActionHandlers.Add(TEXT("set_widget_is_variable"), MakeShared<FSetWidgetIsVariableAction>());
 
 	// =========================================================================
 	// Material Actions (Materials, Shaders, Post-Process)

--- a/Source/UEEditorMCP/Public/Actions/NodeActions.h
+++ b/Source/UEEditorMCP/Public/Actions/NodeActions.h
@@ -750,6 +750,106 @@ protected:
 
 
 // ============================================================================
+// Async Action Nodes (Third-party plugin support: UForge, etc.)
+// ============================================================================
+
+/** Add an async action node (UK2Node_AsyncAction) by class name.
+ *  Supports any UBlueprintAsyncActionBase subclass, including third-party
+ *  plugins like UForge HTTP & JSON Utility.
+ *
+ *  Params:
+ *    blueprint_name  (required)  Target Blueprint
+ *    class_name      (required)  C++ class name of the async action (e.g. "HTTPProxyAsync")
+ *    factory_function (optional) Factory function name (auto-detected if omitted)
+ *    node_position   (optional)  [X, Y]
+ *    graph_name      (optional)  Target graph (default: EventGraph)
+ *    pin_defaults    (optional)  Object mapping pin_name -> default_value
+ */
+class UEEDITORMCP_API FAddAsyncActionNodeAction : public FBlueprintNodeAction
+{
+public:
+	virtual TSharedPtr<FJsonObject> ExecuteInternal(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context) override;
+protected:
+	virtual bool Validate(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context, FString& OutError) override;
+	virtual FString GetActionName() const override { return TEXT("add_async_action_node"); }
+private:
+	UClass* FindAsyncActionClass(const FString& ClassName) const;
+	UFunction* FindFactoryFunction(UClass* AsyncClass, const FString& FunctionName) const;
+};
+
+
+// ============================================================================
+// Self-Evolution: Dynamic Node Discovery & Creation
+// ============================================================================
+
+/** Search the Blueprint action catalog for available nodes.
+ *  Queries FBlueprintActionDatabase to discover all registered Blueprint actions.
+ *
+ *  Params:
+ *    keyword       (required)  Search term (min 2 chars, matches name/category/keywords)
+ *    category      (optional)  Additional category filter
+ *    max_results   (optional)  Max results to return (default: 50, max: 200)
+ *
+ *  Returns: array of {spawner_id, name, category, node_class, keywords, tooltip}
+ *  Use spawner_id with node.add_generic to create the node.
+ */
+class UEEDITORMCP_API FSearchCatalogAction : public FBlueprintNodeAction
+{
+public:
+	virtual TSharedPtr<FJsonObject> ExecuteInternal(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context) override;
+protected:
+	virtual bool Validate(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context, FString& OutError) override;
+	virtual FString GetActionName() const override { return TEXT("search_catalog"); }
+	virtual bool RequiresSave() const override { return false; }
+};
+
+
+/** Create any Blueprint node using a spawner_id from search_catalog or suggest_next.
+ *  This is the "universal node creator" — replaces 30+ hardcoded node.add_* actions.
+ *
+ *  Params:
+ *    blueprint_name  (required)  Target Blueprint
+ *    spawner_id      (required)  ID from search_catalog or suggest_next
+ *    node_position   (optional)  [X, Y]
+ *    graph_name      (optional)  Target graph (default: EventGraph)
+ *    pin_defaults    (optional)  Object mapping pin_name -> default_value
+ *
+ *  Returns: node_id, node_class, node_title, pins[]
+ */
+class UEEDITORMCP_API FAddGenericNodeAction : public FBlueprintNodeAction
+{
+public:
+	virtual TSharedPtr<FJsonObject> ExecuteInternal(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context) override;
+protected:
+	virtual bool Validate(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context, FString& OutError) override;
+	virtual FString GetActionName() const override { return TEXT("add_generic_node"); }
+};
+
+
+/** Given a node pin, suggest compatible nodes that can connect to it.
+ *  Uses UE's native context-sensitive menu system (FBlueprintActionMenuUtils).
+ *
+ *  Params:
+ *    blueprint_name  (required)  Target Blueprint
+ *    node_id         (required)  GUID of the source node
+ *    pin_name        (required)  Name of the pin to find connections for
+ *    max_results     (optional)  Max results (default: 30, max: 100)
+ *    graph_name      (optional)  Target graph (default: EventGraph)
+ *
+ *  Returns: compatible_actions[], source_pin info, pin_type
+ */
+class UEEDITORMCP_API FSuggestNextAction : public FBlueprintNodeAction
+{
+public:
+	virtual TSharedPtr<FJsonObject> ExecuteInternal(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context) override;
+protected:
+	virtual bool Validate(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context, FString& OutError) override;
+	virtual FString GetActionName() const override { return TEXT("suggest_next"); }
+	virtual bool RequiresSave() const override { return false; }
+};
+
+
+// ============================================================================
 // Graph Topology (P2)
 // ============================================================================
 

--- a/Source/UEEditorMCP/Public/Actions/UMGActions.h
+++ b/Source/UEEditorMCP/Public/Actions/UMGActions.h
@@ -505,3 +505,18 @@ protected:
 	virtual bool Validate(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context, FString& OutError) override;
 	virtual TSharedPtr<FJsonObject> ExecuteInternal(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context) override;
 };
+
+
+/**
+ * Set bIsVariable on a widget component in a Widget Blueprint.
+ * Params: widget_name, target (widget component name), is_variable (bool)
+ */
+class UEEDITORMCP_API FSetWidgetIsVariableAction : public FEditorAction
+{
+public:
+	virtual FString GetActionName() const override { return TEXT("set_widget_is_variable"); }
+
+protected:
+	virtual bool Validate(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context, FString& OutError) override;
+	virtual TSharedPtr<FJsonObject> ExecuteInternal(const TSharedPtr<FJsonObject>& Params, FMCPEditorContext& Context) override;
+};


### PR DESCRIPTION
  新增**自我进化系统** — 3 个 MCP 动作，让 AI 能动态发现和创建**任意**蓝图节点，无需硬编码 C++ 动作。

  Adds a **Self-Evolution System** — 3 new MCP actions that enable AI agents to dynamically discover and create **any** Blueprint node without hardcoded C++ actions.

  ### 新增动作 / New Actions

  - **`node.search_catalog`** — 搜索 `FBlueprintActionDatabase`，查找所有已注册蓝图动作（引擎/插件/项目）。Search all registered Blueprint actions.
  - **`node.add_generic`** — 万能节点创建器，通过 `spawner_id` 创建任意节点，替代 30+ 个硬编码 `node.add_*`。Universal node creator via `UBlueprintNodeSpawner::Invoke()`.
  - **`node.suggest_next`** — 上下文感知推荐，给定引脚返回所有兼容节点（等同于右键拖线菜单）。Context-sensitive suggestions via `FBlueprintActionMenuUtils::MakeContextMenu()`.

  另含 **`node.add_async_action`**：支持创建任意 `UK2Node_AsyncAction` 子类节点（第三方插件支持）。

  ### 为什么需要 / Why This Matters

  之前 / Before：每个新节点类型需要写 C++ → 编译 → 重启 UE
  之后 / After：
  search_catalog("HTTP") → 找到 spawner_id → add_generic 直接创建
  suggest_next(pin) → 发现兼容节点 → add_generic → 连线 → 循环

  ### 实现细节 / Implementation
  - `SelfEvolution` 命名空间，`TWeakObjectPtr` 缓存（自动清理，上限 5000）
  - 依赖 `BlueprintGraph` + `Kismet` 模块（已在 Build.cs 中）
  - 4 文件修改，866 行新增 / 4 files changed, 866 insertions
  - 动作总数 / Total actions: 151 → 154
  - 测试环境 / Tested on UE 5.7.4